### PR TITLE
Fixed issue for About tab overlap

### DIFF
--- a/public/stylesheets/materialize.css
+++ b/public/stylesheets/materialize.css
@@ -7354,7 +7354,7 @@ nav .brand-logo {
   position: absolute;
   color: #fff;
   display: inline-block;
-  font-size: 2.1rem;
+  font-size: 1.5rem;
   padding: 0;
   white-space: nowrap;
 }
@@ -7406,7 +7406,7 @@ nav ul li.active {
 
 nav ul a {
   transition: background-color .3s;
-  font-size: 1rem;
+  font-size: 0.8rem;
   color: #fff;
   display: block;
   padding: 0 15px;


### PR DESCRIPTION
The new 'About' tab we created overlaps with other text on the navbar for some screen sizes. Changed the font size in materialize.css to make the navbar font smaller to prevent overlap.