### PR TITLE
Updated awards.csv to include 2016-17 DTAs

### DIFF
--- a/data/awards.csv
+++ b/data/awards.csv
@@ -1,3 +1,13 @@
+Tarek Zohdi,2017,Distinguished Teaching Award
+Carlos Norena,2017,Distinguished Teaching Award
+Michael Manga,2017,Distinguished Teaching Award
+Khalid Kadir,2017,Distinguished Teaching Award
+Ian Duncan,2017,Distinguished Teaching Award
+Wendy Brown,2016,Distinguished Teaching Award
+Georgina Kleege,2016,Distinguished Teaching Award
+Anne Joseph O'Connell,2016,Distinguished Teaching Award
+Lisa Pruitt,2016,Distinguished Teaching Award
+Irfan Siddiqi,2016,Distinguished Teaching Award
 Eugene Chiang,2014,Distinguished Teaching Award
 Munis Faruqui,2014,Distinguished Teaching Award
 Ron Hassner,2014,Distinguished Teaching Award
@@ -276,7 +286,7 @@ David Henkin,2007,Distinguished Teaching Award
 Charis Thompson,2007,Distinguished Teaching Award
 Shachar Kariv,2006,Distinguished Teaching Award
 Ann M. Kring,2006,Distinguished Teaching Award
-Carlos F. NoreÃ±a,2005,Distinguished Teaching Award
+Carlos F. Noreí±a,2005,Distinguished Teaching Award
 Thomas B. Gold,2005,Distinguished Teaching Award
 Steven Fish,2003,Excellence in undergraduate and graduate classroom teaching
 Rosemary Joyce,2003,Excellence in undergraduate and graduate classroom teaching
@@ -288,7 +298,7 @@ John H. McWhorter,2001,Excellence in undergraduate and graduate classroom teachi
 Kenneth W. Wachter,2001,Excellence in undergraduate and graduate classroom teaching
 Robin Einhorn,2000,Excellence in undergraduate and graduate classroom teaching
 Stephen Hinshaw,2000,Excellence in undergraduate and graduate classroom teaching
-Arlie R. Hochschild,Excellence in undergraduate and graduate classroom teaching
+Arlie R. Hochschild,Excellence in undergraduate and graduate classroom teaching,
 Christopher Ansell,1999,Excellence in undergraduate and graduate classroom teaching
 Andrew J. Garrett,2000,Excellence in undergraduate and graduate classroom teaching
 Paul A. Ruud,2000,Excellence in undergraduate and graduate classroom teaching


### PR DESCRIPTION
Updated awards.csv spreadsheet to include the most recent professors who received the Distinguished Teaching Award
Will probably have to run 'rake db:seed' again for changes to take effect.