### PR TITLE
Renamed Compare Courses 'Action' column to 'Delete'

### DIFF
--- a/app/views/courses/compare.html.haml
+++ b/app/views/courses/compare.html.haml
@@ -25,7 +25,7 @@
                 %th{"data-field": "professor"} Professor
                 %th{"data-field": "professor_rating_overall"} Avg. Professor Rating (Overall)
                 %th{"data-field": "professor_rating_course"} Avg. Professor Rating (This Course) 
-                %th{"data-field": "Action"} Action
+                %th{"data-field": "Action"} Delete
             %tbody#selected-courses
 = javascript_include_tag '/javascripts/courses_compare.js'
 


### PR DESCRIPTION
Renamed column per Patterson's request.
Changed 'Action' to 'Delete' so it's easier to understand. 