### PR TITLE
Fix Autocomplete Validation

### DIFF
--- a/public/javascripts/courses_compare.js
+++ b/public/javascripts/courses_compare.js
@@ -68,6 +68,7 @@ $(document).ready(function () {
     $('#professor-search').val("");
 
     if (!validate_inputs(selected_professor_name, selected_course_name)) {
+      $('#data-loader').hide();
       return;
     }
 

--- a/public/javascripts/edit.js
+++ b/public/javascripts/edit.js
@@ -40,5 +40,24 @@ $(function() {
         }
       });
   }
+
+  function validate_input(input_string) {
+    if ($.inArray(input_string, all_courses_options) == -1) {
+      alert("That isn't a valid class.");
+      return false;
+    }
+    return true;
+  }
+
+  $("#add-interested-course").submit(function() {
+    let input_string = $('interested-course-search').val();
+    return validate_input(input_string);
+  });
+  $("#add-taken-course").submit(function() {
+    console.log("SwS");
+    let input_string = $('taken-course-search').val();
+    return validate_input(input_string);
+  });
+  
 });
 


### PR DESCRIPTION
Fixed two issues:
1) Adding user courses errors out when a user adds a course via autocomplete input that is not one of the options sourced into autocomplete.
2) Adding a course that doesn't exist in compare courses causes preloader to continuously display loading.

[View bug on Pivotal Tracker](https://www.pivotaltracker.com/story/show/153336919)
